### PR TITLE
fix container to accept HTML elements

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -245,7 +245,7 @@ class FunnelGraph {
             if (!this.container) {
                 throw new Error(`Container cannot be found (selector: ${this.containerSelector}).`);
             }
-        } else if (this.container instanceof HTMLElement) {
+        } else if (this.containerSelector instanceof HTMLElement) {
             this.container = this.containerSelector;
         } else {
             throw new Error('Container must either be a selector string or an HTMLElement.');


### PR DESCRIPTION
Currently, selectors only acceptable as a container passed in options. Passing an HTML element produces the error 'Container must either be a selector string or an HTMLElement.'.
After the fix, both selectors and HTML elements will work the same